### PR TITLE
Make tests work on OS X

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -30,7 +30,7 @@ write_config() {
 
 # Encrypts stdin with GPG
 gpg_encrypt() {
-    local key=$(mktemp)
+    local key=$(mktemp tmp.XXXXXXXXXX)
     printf "%s" "$2" >$key
     printf "%s" "$3" | \
         gpg --no-tty --batch --no-default-keyring --passphrase-fd 9 \


### PR DESCRIPTION
Due to BSD version of `mktemp` the template needs to be passed for it
to work. Template used is the Linux default.
